### PR TITLE
drop user bind info after auth in indirect mode

### DIFF
--- a/lib/Connector/Builtin/Authentication/LDAP.pm
+++ b/lib/Connector/Builtin/Authentication/LDAP.pm
@@ -137,6 +137,10 @@ sub _check_user_password {
         }
     }
 
+    # purge last binding information to enforce use of search bind user
+    # when indirect mode is enabled
+    $self->_purge_bind() if $self->indirect();
+
     if(!defined $userdn) {
       $self->log()->warn('Authentication failed');
       return 0;


### PR DESCRIPTION
This merge request is a followup of the ldap login issue in the openxpki/openxpki#870 project.

The goal is that in indirect mode, later ldap searches should be done within the search_user context and the the user context. In some conditions a failed login attempt could lead to have an open ldap connection without a valid bind and the ldap server will not answer to subsequent searches. See logs in the issue linked above.

That's a workaround that worked for me, but I'm not sure if that's the most elegant solution.